### PR TITLE
[change] reaction result page

### DIFF
--- a/ReactionButton/models.py
+++ b/ReactionButton/models.py
@@ -34,8 +34,18 @@ class Reaction(models.Model):
         result = []
         pres = Presenter.objects.filter(conference=conf).order_by('user')
         for pre in pres:
+            reacs = []
+            reac_raw = cls.objects.filter(dest_user=pre.user, conference=conf)
+            sum = 0
+            for rt in ReactionType.objects.all().order_by("number"):
+                r = reac_raw.filter(reaction_type=rt).first()
+                reacs.append(r)
+                if r != None:
+                    sum += r.count
             result.append({
                 'presenter' : pre,
-                'reactions' : cls.objects.filter(dest_user=pre.user, conference=conf).order_by('reaction_type').reverse()
+                'reactions' : reacs,
+                'sum' : sum
             })
+        result.sort(key=lambda x: x['sum'], reverse=True)
         return result

--- a/ReactionButton/templates/ReactionButton/ReactionResult.html
+++ b/ReactionButton/templates/ReactionButton/ReactionResult.html
@@ -9,10 +9,39 @@
 {% block content %}
 {{block.super}}
 <div class="h2 font-weight-bold">
-  リアクション結果
+  {{conf}}のリアクション結果
 </div>
 <div class="d-flex">
-  {% for r in reactions %}
+  <table class="table table-striped">
+    <thead>
+      <th scope="col" class="text-center">#</th>
+      <th scope="col" class="text-center">プレゼンター</th>
+      {% for rt in reaction_type %}
+      <th scope="col" class="text-center">{{rt.description}}</th>
+      {% endfor %}
+      <th scope="col" class="text-center">合計</th>
+    </thead>
+    <tbody>
+      {% for r in reactions %}
+      <tr>
+        <th scope="row" class="text-center">{{forloop.counter}}</th>
+        <td class="text-center">{{r.presenter.user.get_called_name}}</td>
+        {% for reaction in r.reactions %}
+        <td class="text-center">
+          {% if reaction is not None %}
+          {{reaction.count}}
+          {% else %}
+          0
+          {% endif %}
+        </td>
+        {% endfor %}
+        <td class="text-center">{{r.sum}}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+  <!-- {% for r in reactions %}
   <div class="card m-2">
     <div class="card-body">
       <h4 class="card-title font-weight-bold">
@@ -26,7 +55,7 @@
       </p>
     </div>
   </div>
-  {% endfor %}
+  {% endfor %} -->
 </div>
 {% endblock %}
 

--- a/home/models.py
+++ b/home/models.py
@@ -31,8 +31,6 @@ class Conference(models.Model):
     def getCurrentConference(cls):
         conf = Variable.get().current_conference
         conf_id = conf.id
-        print(conf)
-        print(conf_id)
         return cls.objects.filter(id=conf_id).first()
 
 class Presenter(models.Model):

--- a/home/templates/home/conferencelist.html
+++ b/home/templates/home/conferencelist.html
@@ -14,6 +14,7 @@
     <div class="card-body">
       <h4 class="card-title">{{c.title}}</h4>
       <h6 class="card-subtitle mb-2 text-muted">{{c.subtitle}}</h6>
+      <h6 class="card-subtitle mb-2 text-muted">{{c.event_date}}開催</h6>
       <p class="card-text">
         {{c.description}}
       </p>

--- a/home/views.py
+++ b/home/views.py
@@ -13,7 +13,6 @@ def index(request):
         'current_conf' : Conference.getCurrentConference(),
         'conf_list' : conf_list,
     }
-    print(contents)
     return render(request, 'home/index.html', contents)
 
 def sitemap(request):


### PR DESCRIPTION
変更点
・リアクションボタンページで，開催中の会議に参加しているプレゼンターだけをリストで表示するようにしました．
・リアクション結果ページの見た目を変えました．（合計も表示してみました）
・自分自身にリアクションをとばした場合，音声は流れるが回数に加算されないようにしました．（ポイント稼ぎ防止）